### PR TITLE
feat: implement season-based F1 driver API endpoints

### DIFF
--- a/src/main/java/com/alex/project/myapp/controller/DriverController.java
+++ b/src/main/java/com/alex/project/myapp/controller/DriverController.java
@@ -1,6 +1,7 @@
 package com.alex.project.myapp.controller;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,30 +19,99 @@ import org.springframework.web.bind.annotation.RestController;
 import com.alex.project.myapp.model.Driver;
 import com.alex.project.myapp.service.DriverService;
 
-
-
 @RestController
-@RequestMapping("/api/v1/f1_info/drivers")
+@RequestMapping("/api/v1/f1_info")
 @CrossOrigin(origins = "*")
 public class DriverController {
     @Autowired
     private DriverService driverService;
 
-    // Get all drivers
-    @GetMapping
-    public List<Driver> getAllDrivers() {
-        return driverService.getAllDrivers();
+    // ===== SEASON-BASED ENDPOINTS =====
+    
+    // Get all available seasons
+    @GetMapping("/seasons")
+    public ResponseEntity<List<Integer>> getAvailableSeasons() {
+        List<Integer> seasons = driverService.getAvailableSeasons();
+        return ResponseEntity.ok(seasons);
+    }
+
+    // Get drivers by season
+    @GetMapping("/seasons/{season}/drivers")
+    public ResponseEntity<List<Driver>> getDriversBySeason(@PathVariable Integer season) {
+        List<Driver> drivers = driverService.getDriversBySeason(season);
+        if (drivers.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(drivers);
+    }
+
+    // Get specific driver in a season
+    @GetMapping("/seasons/{season}/drivers/{driverId}")
+    public ResponseEntity<Driver> getDriverBySeasonAndId(
+            @PathVariable Integer season, 
+            @PathVariable Long driverId) {
+        Optional<Driver> driver = driverService.getDriverBySeasonAndId(season, driverId);
+        return driver
+                .map(d -> ResponseEntity.ok(d))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    // Get drivers by team in specific season
+    @GetMapping("/seasons/{season}/teams/{team}/drivers")
+    public ResponseEntity<List<Driver>> getDriversBySeasonAndTeam(
+            @PathVariable Integer season,
+            @PathVariable String team) {
+        List<Driver> drivers = driverService.getDriversBySeasonAndTeam(season, team);
+        if (drivers.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(drivers);
+    }
+
+    // Get all teams in a specific season
+    @GetMapping("/seasons/{season}/teams")
+    public ResponseEntity<List<String>> getTeamsBySeason(@PathVariable Integer season) {
+        List<String> teams = driverService.getTeamsBySeason(season);
+        if (teams.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(teams);
+    }
+
+    // Get season statistics
+    @GetMapping("/seasons/{season}/stats")
+    public ResponseEntity<Map<String, Object>> getSeasonStats(@PathVariable Integer season) {
+        Map<String, Object> stats = driverService.getSeasonStatistics(season);
+        return ResponseEntity.ok(stats);
+    }
+
+    // ===== CURRENT SEASON ENDPOINTS (2024) =====
+    
+    // Get current season drivers (defaults to 2024)
+    @GetMapping("/drivers")
+    public ResponseEntity<List<Driver>> getCurrentSeasonDrivers() {
+        List<Driver> drivers = driverService.getCurrentSeasonDrivers();
+        return ResponseEntity.ok(drivers);
+    }
+
+    // ===== LEGACY/ADMIN ENDPOINTS =====
+    
+    // Get all drivers (all seasons) - mainly for admin purposes
+    @GetMapping("/drivers/all")
+    public ResponseEntity<List<Driver>> getAllDrivers() {
+        List<Driver> drivers = driverService.getAllDrivers();
+        return ResponseEntity.ok(drivers);
     }
 
     // Create a new driver
-    @PostMapping 
+    @PostMapping("/drivers") 
     public ResponseEntity<Driver> createDriver(@RequestBody Driver driver) {
         Driver savedDriver = driverService.createDriver(driver);
         return ResponseEntity.created(null).body(savedDriver);
     }
 
-    // Get driver by ID
-    @GetMapping("/{id}")
+    // Get driver by ID (regardless of season)
+    @GetMapping("/drivers/{id}")
     public ResponseEntity<Driver> getDriverById(@PathVariable Long id) {
         Optional<Driver> driverO = driverService.getDriverById(id);
         return driverO
@@ -50,25 +120,22 @@ public class DriverController {
     }
 
     // Update a driver
-    @PutMapping("/{id}")
+    @PutMapping("/drivers/{id}")
     public ResponseEntity<Driver> updateDriver(@PathVariable Long id, @RequestBody Driver driverDetails) {
-        Optional<Driver> updatedDriver = driverService.updateDriver(id,driverDetails);
-
+        Optional<Driver> updatedDriver = driverService.updateDriver(id, driverDetails);
         return updatedDriver
                 .map(driver -> ResponseEntity.ok(driver))
                 .orElse(ResponseEntity.notFound().build());
     }
 
     // Delete a driver
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/drivers/{id}")
     public ResponseEntity<Void> deleteDriver(@PathVariable Long id) {
         Boolean deleted = driverService.deleteDriver(id);
-
         if(deleted){
             return ResponseEntity.noContent().build();
         } else {
             return ResponseEntity.notFound().build();
         }
     }    
-    
 }

--- a/src/main/java/com/alex/project/myapp/model/Driver.java
+++ b/src/main/java/com/alex/project/myapp/model/Driver.java
@@ -1,15 +1,18 @@
 package com.alex.project.myapp.model;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @Entity
+@Table(name = "driver")
 @NoArgsConstructor
 @AllArgsConstructor
 public class Driver {
@@ -18,9 +21,21 @@ public class Driver {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "first_name")
     private String firstName;
+    
+    @Column(name = "last_name")
     private String lastName;
+    
+    @Column(name = "team")
     private String team;
+    
+    @Column(name = "nationality")
     private String nationality;
-    private Long driverNumber;
+    
+    @Column(name = "driver_number")
+    private Integer driverNumber;
+    
+    @Column(name = "season")
+    private Integer season;
 }

--- a/src/main/java/com/alex/project/myapp/repository/DriverRepository.java
+++ b/src/main/java/com/alex/project/myapp/repository/DriverRepository.java
@@ -1,11 +1,35 @@
 package com.alex.project.myapp.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.alex.project.myapp.model.Driver;
 
 @Repository
 public interface DriverRepository extends JpaRepository<Driver, Long>{
-
+    
+    // Find drivers by season
+    List<Driver> findBySeason(Integer season);
+    
+    // Find driver by season and ID
+    Optional<Driver> findBySeasonAndId(Integer season, Long id);
+    
+    // Find drivers by season and team (case-insensitive)
+    List<Driver> findBySeasonAndTeamIgnoreCase(Integer season, String team);
+    
+    // Get all available seasons ordered by year (newest first)
+    @Query("SELECT DISTINCT d.season FROM Driver d ORDER BY d.season DESC")
+    List<Integer> findDistinctSeasons();
+    
+    // Count drivers by season
+    Long countBySeason(Integer season);
+    
+    // Find all teams in a specific season
+    @Query("SELECT DISTINCT d.team FROM Driver d WHERE d.season = :season ORDER BY d.team")
+    List<String> findDistinctTeamsBySeason(@Param("season") Integer season);
 }

--- a/src/main/java/com/alex/project/myapp/service/DriverService.java
+++ b/src/main/java/com/alex/project/myapp/service/DriverService.java
@@ -1,6 +1,8 @@
 package com.alex.project.myapp.service;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +16,7 @@ public class DriverService {
     @Autowired
     private DriverRepository driverRepository;
 
+    // Legacy methods (for backward compatibility)
     public List<Driver> getAllDrivers(){
         return driverRepository.findAll();
     }
@@ -36,6 +39,7 @@ public class DriverService {
             existingDriver.setTeam(driverDetails.getTeam());
             existingDriver.setNationality(driverDetails.getNationality());
             existingDriver.setDriverNumber(driverDetails.getDriverNumber());
+            existingDriver.setSeason(driverDetails.getSeason());
             return Optional.of(driverRepository.save(existingDriver));
         } else {
             return Optional.empty();
@@ -51,5 +55,40 @@ public class DriverService {
         } else {
             return false;
         }
+    }
+
+    // New season-based methods
+    public List<Driver> getDriversBySeason(Integer season) {
+        return driverRepository.findBySeason(season);
+    }
+
+    public Optional<Driver> getDriverBySeasonAndId(Integer season, Long id) {
+        return driverRepository.findBySeasonAndId(season, id);
+    }
+
+    public List<Driver> getDriversBySeasonAndTeam(Integer season, String team) {
+        return driverRepository.findBySeasonAndTeamIgnoreCase(season, team);
+    }
+
+    public List<Integer> getAvailableSeasons() {
+        return driverRepository.findDistinctSeasons();
+    }
+
+    public List<String> getTeamsBySeason(Integer season) {
+        return driverRepository.findDistinctTeamsBySeason(season);
+    }
+
+    public Map<String, Object> getSeasonStatistics(Integer season) {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put("season", season);
+        stats.put("totalDrivers", driverRepository.countBySeason(season));
+        stats.put("teams", driverRepository.findDistinctTeamsBySeason(season));
+        stats.put("totalTeams", driverRepository.findDistinctTeamsBySeason(season).size());
+        return stats;
+    }
+
+    // Current season methods (defaults to 2024)
+    public List<Driver> getCurrentSeasonDrivers() {
+        return getDriversBySeason(2024);
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,40 +1,57 @@
 -- F1 2024 Grid Data
 -- Red Bull Racing
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Max', 'Verstappen', 'Red Bull Racing', 'Netherlands', 1);
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Sergio', 'Pérez', 'Red Bull Racing', 'Mexico', 11);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Max', 'Verstappen', 'Red Bull Racing', 'Netherlands', 1, 2024);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Sergio', 'Pérez', 'Red Bull Racing', 'Mexico', 11, 2024);
 
 -- Ferrari
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Charles', 'Leclerc', 'Ferrari', 'Monaco', 16);
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Carlos', 'Sainz Jr.', 'Ferrari', 'Spain', 55);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Charles', 'Leclerc', 'Ferrari', 'Monaco', 16, 2024);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Carlos', 'Sainz Jr.', 'Ferrari', 'Spain', 55, 2024);
 
 -- McLaren
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Lando', 'Norris', 'McLaren', 'United Kingdom', 4);
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Oscar', 'Piastri', 'McLaren', 'Australia', 81);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Lando', 'Norris', 'McLaren', 'United Kingdom', 4, 2024);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Oscar', 'Piastri', 'McLaren', 'Australia', 81, 2024);
 
 -- Mercedes
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Lewis', 'Hamilton', 'Mercedes', 'United Kingdom', 44);
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('George', 'Russell', 'Mercedes', 'United Kingdom', 63);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Lewis', 'Hamilton', 'Mercedes', 'United Kingdom', 44, 2024);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('George', 'Russell', 'Mercedes', 'United Kingdom', 63, 2024);
 
 -- Aston Martin
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Fernando', 'Alonso', 'Aston Martin', 'Spain', 14);
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Lance', 'Stroll', 'Aston Martin', 'Canada', 18);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Fernando', 'Alonso', 'Aston Martin', 'Spain', 14, 2024);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Lance', 'Stroll', 'Aston Martin', 'Canada', 18, 2024);
 
 -- Alpine
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Esteban', 'Ocon', 'Alpine', 'France', 31);
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Pierre', 'Gasly', 'Alpine', 'France', 10);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Esteban', 'Ocon', 'Alpine', 'France', 31, 2024);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Pierre', 'Gasly', 'Alpine', 'France', 10, 2024);
 
 -- Williams
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Alex', 'Albon', 'Williams', 'Thailand', 23);
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Logan', 'Sargeant', 'Williams', 'United States', 2);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Alex', 'Albon', 'Williams', 'Thailand', 23, 2024);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Logan', 'Sargeant', 'Williams', 'United States', 2, 2024);
 
--- AlphaTauri (now RB)
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Yuki', 'Tsunoda', 'RB', 'Japan', 22);
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Daniel', 'Ricciardo', 'RB', 'Australia', 3);
+-- RB (formerly AlphaTauri)
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Yuki', 'Tsunoda', 'RB', 'Japan', 22, 2024);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Daniel', 'Ricciardo', 'RB', 'Australia', 3, 2024);
 
--- Alfa Romeo (now Kick Sauber)
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Valtteri', 'Bottas', 'Kick Sauber', 'Finland', 77);
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Zhou', 'Guanyu', 'Kick Sauber', 'China', 24);
+-- Kick Sauber (formerly Alfa Romeo)
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Valtteri', 'Bottas', 'Kick Sauber', 'Finland', 77, 2024);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Zhou', 'Guanyu', 'Kick Sauber', 'China', 24, 2024);
 
 -- Haas
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Kevin', 'Magnussen', 'Haas', 'Denmark', 20);
-INSERT INTO driver (first_name, last_name, team, nationality, driver_number) VALUES ('Nico', 'Hülkenberg', 'Haas', 'Germany', 27);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Kevin', 'Magnussen', 'Haas', 'Denmark', 20, 2024);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Nico', 'Hülkenberg', 'Haas', 'Germany', 27, 2024);
+
+-- F1 2023 Grid Data (sample for demonstration)
+-- Red Bull Racing
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Max', 'Verstappen', 'Red Bull Racing', 'Netherlands', 1, 2023);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Sergio', 'Pérez', 'Red Bull Racing', 'Mexico', 11, 2023);
+
+-- Ferrari
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Charles', 'Leclerc', 'Ferrari', 'Monaco', 16, 2023);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Carlos', 'Sainz Jr.', 'Ferrari', 'Spain', 55, 2023);
+
+-- Mercedes
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Lewis', 'Hamilton', 'Mercedes', 'United Kingdom', 44, 2023);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('George', 'Russell', 'Mercedes', 'United Kingdom', 63, 2023);
+
+-- McLaren
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Lando', 'Norris', 'McLaren', 'United Kingdom', 4, 2023);
+INSERT INTO driver (first_name, last_name, team, nationality, driver_number, season) VALUES ('Oscar', 'Piastri', 'McLaren', 'Australia', 81, 2023);


### PR DESCRIPTION
- Add season field to Driver entity with proper JPA mapping
- Extend DriverRepository with season-based query methods
- Enhance DriverService with season filtering and statistics
- Create comprehensive season-based REST endpoints:
  * GET /seasons - list available seasons
  * GET /seasons/{season}/drivers - drivers by season
  * GET /seasons/{season}/drivers/{id} - specific driver in season
  * GET /seasons/{season}/teams - teams by season
  * GET /seasons/{season}/teams/{team}/drivers - team drivers by season
  * GET /seasons/{season}/stats - season statistics
- Maintain backward compatibility with legacy endpoints
- Update data.sql with 2024 F1 grid and season information
- Add proper HTTP status codes and error handling

Breaking changes: Driver entity now includes mandatory season field