### PR TITLE
feat: dockerized the application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM maven:3.9.9-amazoncorretto-21 AS build
+WORKDIR /app
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+COPY src ./src
+RUN mvn package -DskipTests
+
+# more light weight images are yet to be explored.
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /app/target/*.jar /app/app.jar
+EXPOSE 8081
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+services:
+  f1_info_api:
+    build:
+      context: .
+    image: f1-info-api
+    container_name: f1-info-api
+    ports:
+      - "8081:8081"

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,20 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.11.0</version>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.32</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
### Summary
This PR completes the "Dockerise the application" issue #8 adding a multi-stage Dockerfile and ensuring the project builds successfully inside Docker.

### Key Changes
- Added multi-stage Dockerfile (Maven for build,  JRE for runtime) in the root of the project directory to make the application easy to run and deploy in any environment.
- Added Lombok dependency to pom.xml because the project uses Lombok annotations (`@Data`, `@Getter`, etc.) but pom.xml was missing the dependency

### Why This Was Needed
- Without Lombok, Maven fails during compilation inside Docker
- The application had no containerization setup, so CI/CD and environment consistency were missing. This is the first step to develop a ci/cd system for the application.
- Multi-stage approach significantly reduces the final image size and improves portability

### Testing
- Successfully build and run the application using `docker compose up  -d . ` from within the project root directory. The api will be available at `http://localhost:8081/api/*`.

closes #8 
